### PR TITLE
#wrapのheight指定を削除

### DIFF
--- a/app/assets/stylesheets/modules/_sign_up.scss
+++ b/app/assets/stylesheets/modules/_sign_up.scss
@@ -9,7 +9,6 @@ html{
 
 #wrap{
   width: 100%;
-  height: 100vh;
   padding-top: 0;
   background-color: #f5f5f5;
   .main-content01{


### PR DESCRIPTION
企業・ユーザー登録画面のウィンドウが下にスクロールしなくなったためheight指定を削除